### PR TITLE
Fix apple help bundle ID

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -291,4 +291,4 @@ texinfo_documents = [
 #texinfo_no_detailmenu = False
 
 # apple help book
-applehelp_bundle_id = 'com.kvibes.MediaElch'
+applehelp_bundle_id = 'com.kvibes.MediaElch.help'


### PR DESCRIPTION
My fault!
The help ID shouldn’t be equal to the app ID.

So, It's working :)

![2018-07-22 9 36 03](https://user-images.githubusercontent.com/12618414/43041307-a0748134-8d9f-11e8-8164-e0e621d40a8b.png)
![2018-07-22 9 36 44](https://user-images.githubusercontent.com/12618414/43041308-a3cb73f6-8d9f-11e8-9c92-e8168fb867a8.png)
